### PR TITLE
🔒 Fix HTML Injection in Telegram Bot Status Message

### DIFF
--- a/internal/telegram/handlers/commands.go
+++ b/internal/telegram/handlers/commands.go
@@ -163,7 +163,7 @@ func (h *Handlers) HandleStatus(m *tgbotapi.Message) (tgbotapi.MessageConfig, er
 	}
 
 	message := fmt.Sprintf(statusMessage,
-		m.From.FirstName,
+		html.EscapeString(m.From.FirstName),
 		stats.TotalDuties,
 		stats.DutiesThisMonth,
 		nextDuty,


### PR DESCRIPTION
🎯 **What:** The user's Telegram first name (`m.From.FirstName`) was being passed directly into an `html` parsed message template (`statusMessage`) without escaping, leading to an HTML injection vulnerability.
⚠️ **Risk:** A malicious user could change their Telegram first name to include arbitrary HTML tags, potentially breaking the bot's message formatting or executing unintended formatting in the Telegram client.
🛡️ **Solution:** The user's first name is now wrapped with `html.EscapeString()` before being formatted into the message string.

---
*PR created automatically by Jules for task [9462979864248671523](https://jules.google.com/task/9462979864248671523) started by @korjavin*