### PR TITLE
🧹 refactor(notifier): change Start() to return error instead of os.Exit(1)

### DIFF
--- a/internal/notification/notifier.go
+++ b/internal/notification/notifier.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html"
 	"log/slog"
-	"os"
 	"strings"
 	"time"
 
@@ -54,16 +53,16 @@ func NewNotifier(s store.Store, sched Scheduler, bot TelegramBot, chatID int64, 
 }
 
 // Start initializes and starts the cron scheduler.
-func (n *Notifier) Start() {
+func (n *Notifier) Start() error {
 	slog.Info(fmt.Sprintf("Starting notifier with schedule '%s' in %s timezone", n.cronSpec, n.location))
 
 	n.cron = cron.New(cron.WithLocation(n.location))
 	_, err := n.cron.AddFunc(n.cronSpec, n.checkAndNotify)
 	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to add cron job: %v", err))
-		os.Exit(1)
+		return fmt.Errorf("failed to add cron job: %w", err)
 	}
 	n.cron.Start()
+	return nil
 }
 
 // Stop gracefully stops the cron scheduler.


### PR DESCRIPTION
🎯 **What:** Changed `Start()` method in `internal/notification/notifier.go` to return an `error` rather than calling `log.Fatalf`/`os.Exit(1)`.
💡 **Why:** This prevents the package code from forcefully terminating the process on failures, allowing the application to handle errors gracefully, which improves overall stability and code health.
✅ **Verification:** Verified the code compiles successfully (`go build ./...`) and ran the full test suite (`go test -mod=vendor -race -count=1 ./...`), ensuring all tests pass. There were no active uses of `Notifier.Start()` requiring changes in the main application.
✨ **Result:** Improved maintainability and application robustness by adopting standard Go error handling patterns.

---
*PR created automatically by Jules for task [860137397178263434](https://jules.google.com/task/860137397178263434) started by @korjavin*