### PR TITLE
🧪 test: improve determineWinner coverage with table-driven tests

### DIFF
--- a/internal/notification/notifier_test.go
+++ b/internal/notification/notifier_test.go
@@ -488,24 +488,78 @@ func TestRenderBarChart(t *testing.T) {
 }
 
 func TestDetermineWinner(t *testing.T) {
-	stats := []*store.UserWeeklyStats{
-		{Name: "Alice", CompletedCount: 5, AvgLateSeconds: 3600},
-		{Name: "Bob", CompletedCount: 10, AvgLateSeconds: 0},
-		{Name: "Charlie", CompletedCount: 10, AvgLateSeconds: 1800}, // Bob wins over Charlie (less late)
+	tests := []struct {
+		name     string
+		stats    []*store.UserWeeklyStats
+		expected string // Expected winner name, empty string means nil expected
+	}{
+		{
+			name:     "empty list",
+			stats:    []*store.UserWeeklyStats{},
+			expected: "",
+		},
+		{
+			name: "single user",
+			stats: []*store.UserWeeklyStats{
+				{Name: "Alice", CompletedCount: 5, AvgLateSeconds: 0},
+			},
+			expected: "Alice",
+		},
+		{
+			name: "distinct completed counts",
+			stats: []*store.UserWeeklyStats{
+				{Name: "Alice", CompletedCount: 5, AvgLateSeconds: 3600},
+				{Name: "Bob", CompletedCount: 10, AvgLateSeconds: 0},
+			},
+			expected: "Bob",
+		},
+		{
+			name: "tie completed count, lower avg late seconds wins",
+			stats: []*store.UserWeeklyStats{
+				{Name: "Bob", CompletedCount: 10, AvgLateSeconds: 0},
+				{Name: "Charlie", CompletedCount: 10, AvgLateSeconds: 1800},
+			},
+			expected: "Bob",
+		},
+		{
+			name: "tie completed count, higher avg late seconds loses",
+			stats: []*store.UserWeeklyStats{
+				{Name: "Alice", CompletedCount: 10, AvgLateSeconds: 1800},
+				{Name: "Bob", CompletedCount: 10, AvgLateSeconds: 0},
+			},
+			expected: "Bob",
+		},
+		{
+			name: "absolute tie, first user wins",
+			stats: []*store.UserWeeklyStats{
+				{Name: "Alice", CompletedCount: 5, AvgLateSeconds: 0},
+				{Name: "Bob", CompletedCount: 5, AvgLateSeconds: 0},
+			},
+			expected: "Alice",
+		},
+		{
+			name: "complex case",
+			stats: []*store.UserWeeklyStats{
+				{Name: "Alice", CompletedCount: 5, AvgLateSeconds: 3600},
+				{Name: "Bob", CompletedCount: 10, AvgLateSeconds: 1800},
+				{Name: "Charlie", CompletedCount: 10, AvgLateSeconds: 0},
+				{Name: "Dave", CompletedCount: 8, AvgLateSeconds: 0},
+			},
+			expected: "Charlie",
+		},
 	}
-	winner := determineWinner(stats)
-	assert.NotNil(t, winner)
-	assert.Equal(t, "Bob", winner.Name)
 
-	stats2 := []*store.UserWeeklyStats{
-		{Name: "Alice", CompletedCount: 5, AvgLateSeconds: 0},
-		{Name: "Bob", CompletedCount: 5, AvgLateSeconds: 0}, // Alice wins (first in list)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			winner := determineWinner(tt.stats)
+			if tt.expected == "" {
+				assert.Nil(t, winner)
+			} else {
+				assert.NotNil(t, winner)
+				assert.Equal(t, tt.expected, winner.Name)
+			}
+		})
 	}
-	winner2 := determineWinner(stats2)
-	assert.NotNil(t, winner2)
-	assert.Equal(t, "Alice", winner2.Name)
-
-	assert.Nil(t, determineWinner([]*store.UserWeeklyStats{}))
 }
 
 func TestSendWeeklyChoreStats(t *testing.T) {


### PR DESCRIPTION
🎯 **What:** The `determineWinner` helper function in `internal/notification/notifier.go` was previously covered by a basic unit test that did not adequately test various tie-breaking and edge-case scenarios.
📊 **Coverage:** The new table-driven unit test now explicitly covers:
- Empty lists (returns `nil`)
- Single user lists
- Distinct completed counts
- Ties in completed counts resolved by lower average late seconds
- Ties in completed counts where higher average late seconds loses
- Absolute ties correctly falling back to the first user found (stable sorting)
- A complex case involving multiple participants.
✨ **Result:** Test coverage and confidence in the `determineWinner` logic have significantly improved, ensuring the tie-breaker correctly calculates the weekly winner.

---
*PR created automatically by Jules for task [6689235248507388853](https://jules.google.com/task/6689235248507388853) started by @korjavin*