### PR TITLE
fix: prevent SQLITE_BUSY on concurrent cron writes

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -27,6 +27,23 @@ func New(ctx context.Context, dataSourceName string) (*SQLiteStore, error) {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}
 
+	// SQLite permits only one writer at a time. Without these settings a
+	// concurrent write (e.g. the month-end ratings and daily-completion cron
+	// jobs both firing at 21:00 Berlin) fails immediately with SQLITE_BUSY.
+	// Serialize all access through a single connection, enable WAL, and add a
+	// busy timeout as a backstop for any out-of-process access.
+	db.SetMaxOpenConns(1)
+	for _, pragma := range []string{
+		"PRAGMA journal_mode = WAL",
+		"PRAGMA busy_timeout = 5000",
+		"PRAGMA foreign_keys = ON",
+	} {
+		if _, err := db.ExecContext(ctx, pragma); err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("failed to set %q: %w", pragma, err)
+		}
+	}
+
 	s := &SQLiteStore{db: db}
 
 	if err := s.migrate(ctx); err != nil {


### PR DESCRIPTION
## Problem

Production bot reported *"Sviniya grant to the winner failed"* in the May 2026 monthly ratings digest. Logs showed:

```
level=ERROR msg="error granting sviniya to monthly rating winner" winner=Vasiliy
err="could not record sviniya monthly grant: database is locked (5) (SQLITE_BUSY)"
```

The month-end ratings cron and the daily-completion cron both fire at 21:00 Berlin and collided on SQLite's single write lock at the same millisecond. With no `busy_timeout` (modernc default is 0), no WAL, and an unbounded `database/sql` connection pool, the losing writer failed *immediately* with `SQLITE_BUSY` instead of waiting — rolling back the sviniya grant transaction.

## Fix

Configure the DB on open in `internal/store/sqlite/sqlite.go`:

- `SetMaxOpenConns(1)` — serializes in-process access so concurrent cron goroutines can't collide (the decisive fix). Verified both `BeginTx` call sites only touch their `tx` handle, so this introduces no self-deadlock.
- `PRAGMA journal_mode = WAL` + `busy_timeout = 5000` — backstops for any out-of-process access (manual `sqlite3`, Litestream).
- `PRAGMA foreign_keys = ON` — production previously never enforced FKs (only the test DSN did).

## Verification

- `go build ./...`, `go vet`, and store + telegram test suites pass.
- Prod data already remediated out-of-band: Vasiliy's missing May 2026 grant recorded and balance corrected (2 → 3).