### PR TITLE
feat: cap volunteer queue at 7 days, add /set_volunteer for admins

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -20,10 +20,25 @@ func NewScheduler(s store.Store) *Scheduler {
 	return &Scheduler{store: s}
 }
 
-// AddToVolunteerQueue adds days to a user's volunteer queue.
+// MaxVolunteerQueueDays caps how many days a user may hold in the volunteer queue.
+const MaxVolunteerQueueDays = 7
+
+// AddToVolunteerQueue adds days to a user's volunteer queue, capped at
+// MaxVolunteerQueueDays in total (not per call).
 func (s *Scheduler) AddToVolunteerQueue(ctx context.Context, userID int64, days int) error {
 	if days <= 0 {
 		return fmt.Errorf("days must be positive")
+	}
+	user, err := s.store.GetUserByID(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("failed to load user: %w", err)
+	}
+	if user == nil {
+		return fmt.Errorf("user not found")
+	}
+	if user.VolunteerQueueDays+days > MaxVolunteerQueueDays {
+		return fmt.Errorf("volunteer queue is capped at %d days (you already have %d)",
+			MaxVolunteerQueueDays, user.VolunteerQueueDays)
 	}
 	return s.store.AddToVolunteerQueue(ctx, userID, days)
 }

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -352,6 +352,17 @@ func TestScheduler_AddToVolunteerQueue(t *testing.T) {
 	if mock.users[0].VolunteerQueueDays != 3 {
 		t.Errorf("Expected 3 volunteer queue days, got %d", mock.users[0].VolunteerQueueDays)
 	}
+
+	// Total is capped at MaxVolunteerQueueDays, not per call.
+	if err := scheduler.AddToVolunteerQueue(ctx, 1, 4); err != nil {
+		t.Fatalf("Expected 3+4 days to fit the cap, got %v", err)
+	}
+	if err := scheduler.AddToVolunteerQueue(ctx, 1, 1); err == nil {
+		t.Error("Expected an error when exceeding the cap")
+	}
+	if mock.users[0].VolunteerQueueDays != MaxVolunteerQueueDays {
+		t.Errorf("Expected %d volunteer queue days, got %d", MaxVolunteerQueueDays, mock.users[0].VolunteerQueueDays)
+	}
 }
 
 func TestScheduler_AddToAdminQueue(t *testing.T) {
@@ -597,5 +608,10 @@ func (m *mockStore) GrantSviniyaForMonth(ctx context.Context, year int, month ti
 
 // GetUserByID mocks the GetUserByID method.
 func (m *mockStore) GetUserByID(ctx context.Context, id int64) (*store.User, error) {
+	for _, u := range m.users {
+		if u.ID == id {
+			return u, nil
+		}
+	}
 	return nil, nil
 }

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -242,6 +242,8 @@ func (b *Bot) handleCommand(m *tgbotapi.Message) (tgbotapi.Chattable, error) {
 		return b.handlers.HandleComplete(m)
 	case "sviniya":
 		return b.handlers.HandleSviniya(m)
+	case "set_volunteer":
+		return b.handlers.HandleSetVolunteer(m)
 	case "set_sviniya_balance":
 		return b.handlers.HandleSetSviniyaBalance(m)
 	case "spend":

--- a/internal/telegram/commands.go
+++ b/internal/telegram/commands.go
@@ -40,6 +40,7 @@ var adminOnlyCommands = []tgbotapi.BotCommand{
 	{Command: "list", Description: "List active periodic chores or tasks"},
 	{Command: "complete", Description: "Mark any active chore as completed"},
 	{Command: "overdue", Description: "Send the overdue chores report"},
+	{Command: "set_volunteer", Description: "Set a user's volunteer queue days"},
 	{Command: "set_sviniya_balance", Description: "Set sviniya balance for a user"},
 }
 

--- a/internal/telegram/handlers/commands.go
+++ b/internal/telegram/handlers/commands.go
@@ -25,7 +25,7 @@ const (
 		"/help - Show this help message.\n" +
 		"/status - Show your current duty statistics.\n" +
 		"/schedule - View the duty schedule for the current month.\n" +
-		"/volunteer <days> - Add days to your volunteer queue.\n" +
+		"/volunteer <days> - Add days to your volunteer queue (max 7 in total).\n" +
 		"/explain - Explain how the last assignment was made.\n" +
 		"/chore - View your currently assigned chores.\n" +
 		"/takechore - Volunteer to take an available chore assigned to someone else.\n" +
@@ -47,6 +47,7 @@ const (
 		"/list - View all active periodic chores or regular tasks.\n" +
 		"/complete - Mark any active chore as completed.\n" +
 		"/overdue - Send the overdue chores report.\n" +
+		"/set\\_volunteer <name> <days> - Set a user's volunteer queue (0-7).\n" +
 		"/set\\_sviniya\\_balance - Set sviniya balance for a user."
 
 	statusMessage = "<b>Duty Status for %s:</b>\n\n" +

--- a/internal/telegram/handlers/volunteer.go
+++ b/internal/telegram/handlers/volunteer.go
@@ -3,9 +3,11 @@ package handlers
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/korjavin/dutyassistant/internal/scheduler"
 )
 
 const (
@@ -102,6 +104,42 @@ func (h *Handlers) HandleVolunteerDaysCallback(q *tgbotapi.CallbackQuery) (tgbot
 		fmt.Sprintf("✅ "+volunteerSuccessMessage, days),
 	)
 	return edit, nil
+}
+
+// HandleSetVolunteer lets an admin set a participant's volunteer queue directly.
+// Format: /set_volunteer <name> <days>
+func (h *Handlers) HandleSetVolunteer(m *tgbotapi.Message) (tgbotapi.MessageConfig, error) {
+	isAdmin, err := h.checkAdmin(m.From.ID)
+	if err != nil || !isAdmin {
+		return tgbotapi.NewMessage(m.Chat.ID, adminOnlyMessage), nil
+	}
+
+	usage := fmt.Sprintf("Usage: /set_volunteer <name> <days>\nExample: <code>/set_volunteer Ivan 3</code> (0-%d)", scheduler.MaxVolunteerQueueDays)
+	args := strings.Fields(m.CommandArguments())
+	if len(args) != 2 {
+		msg := tgbotapi.NewMessage(m.Chat.ID, usage)
+		msg.ParseMode = tgbotapi.ModeHTML
+		return msg, nil
+	}
+
+	days, err := strconv.Atoi(args[1])
+	if err != nil || days < 0 || days > scheduler.MaxVolunteerQueueDays {
+		msg := tgbotapi.NewMessage(m.Chat.ID, fmt.Sprintf("⚠️ Days must be a number between 0 and %d.\n\n%s", scheduler.MaxVolunteerQueueDays, usage))
+		msg.ParseMode = tgbotapi.ModeHTML
+		return msg, nil
+	}
+
+	user, err := h.Store.GetUserByName(context.Background(), args[0])
+	if err != nil || user == nil {
+		return tgbotapi.NewMessage(m.Chat.ID, fmt.Sprintf("❌ "+userNotFoundMessage, args[0])), nil
+	}
+
+	user.VolunteerQueueDays = days
+	if err := h.Store.UpdateUser(context.Background(), user); err != nil {
+		return tgbotapi.NewMessage(m.Chat.ID, fmt.Sprintf("❌ Failed to update volunteer queue: %v", err)), nil
+	}
+
+	return tgbotapi.NewMessage(m.Chat.ID, fmt.Sprintf("✅ Volunteer queue for %s set to %d day(s).", user.FirstName, days)), nil
 }
 
 // HandleVolunteerCustomCallback handles the custom day input request


### PR DESCRIPTION
## What

- `/volunteer` is now capped: a user's volunteer queue can hold at most **7 days total**. Enforced in `scheduler.AddToVolunteerQueue`, the single choke point both the `/volunteer <days>` path and the inline-keyboard callback route through — so the cap can't be farmed by repeating the command.
- New admin command `/set_volunteer <name> <days>` (0–7) sets a participant's volunteer queue directly. Reuses `Store.UpdateUser`, which already persists `volunteer_queue_days` — no new store method, no mock churn.
- Wired into command dispatch, Telegram autocomplete (admin scope), and `/help`.

## Test

`scheduler_test.go` covers the cap on totals (3+4 fits, +1 rejected). The mock's `GetUserByID` was a `nil, nil` stub; made it real so the cap is actually exercised.

`go vet ./...` and `go test ./...` pass.